### PR TITLE
Brandon form function split

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,11 +27,11 @@
         <form id="projectsForm">
         <div class="mb-3">
           <label for="exampleFormControlInput1" class="form-label">Title</label>
-          <input type="text" class="form-control" id="exampleFormControlInput1 titleInput" placeholder="Title">
+          <input type="text" class="form-control" id="titleInput" placeholder="Title">
         </div>
         <div class="mb-3">
           <label for="exampleFormControlTextarea1" class="form-label">Description</label>
-          <textarea class="form-control" id="exampleFormControlTextarea1 descriptionInput" rows="3"></textarea>
+          <textarea class="form-control" id="descriptionInput" rows="3"></textarea>
         </div>
         <button type="submit" class="btn btn-primary" id="submitProjects">Submit</button>
       </form>

--- a/main.js
+++ b/main.js
@@ -134,15 +134,32 @@ document.addEventListener("submit", (e) => {
 
   const newProject = {
     id: projectsData.length + 1,
-    title: newTitle,
-    description: newDescription,
+    title: newTitle.value,
+    description: newDescription.value,
     visibility: "private",
   };
   projectsData.unshift(newProject);
   projectsCard();
   form.reset();
-});
+}); 
 
+// const form = document.querySelector("#newProjectForm");
+// document.addEventListener("submit", (e) => {
+//   e.preventDefault();
+
+//   const newTitle = document.querySelector("#titleInput");
+//   const newDescription = document.querySelector("#descriptionInput");
+
+//   const newProject = {
+//     id: projectsData.length + 1,
+//     title: newTitle,
+//     description: newDescription,
+//     visibility: "private",
+//   };
+//   projectsData.unshift(newProject);
+//   projectsCard();
+//   form.reset();
+// });
 
 
 

--- a/main.js
+++ b/main.js
@@ -138,9 +138,17 @@ document.addEventListener("submit", (e) => {
     description: newDescription.value,
     visibility: "private",
   };
+
+  const reset = () => {
+    const box1 = document.getElementById("titleInput");
+    const box2 = document.getElementById("descriptionInput");
+    box1.value = "";
+    box2.value = "";
+  }
+
   projectsData.unshift(newProject);
   projectsCard();
-  
+  reset();
 }); 
 
 

--- a/main.js
+++ b/main.js
@@ -140,27 +140,8 @@ document.addEventListener("submit", (e) => {
   };
   projectsData.unshift(newProject);
   projectsCard();
-  form.reset();
+  
 }); 
-
-// const form = document.querySelector("#newProjectForm");
-// document.addEventListener("submit", (e) => {
-//   e.preventDefault();
-
-//   const newTitle = document.querySelector("#titleInput");
-//   const newDescription = document.querySelector("#descriptionInput");
-
-//   const newProject = {
-//     id: projectsData.length + 1,
-//     title: newTitle,
-//     description: newDescription,
-//     visibility: "private",
-//   };
-//   projectsData.unshift(newProject);
-//   projectsCard();
-//   form.reset();
-// });
-
 
 
 const profileCard = () => {

--- a/packages.html
+++ b/packages.html
@@ -43,11 +43,11 @@
         <h1>Create new package</h1>
         <div class="mb-3">
           <label for="exampleFormControlInput1" class="form-label">Title</label>
-          <input type="text" class="form-control" id="exampleFormControlInput1 titleInput" placeholder="Title">
+          <input type="text" class="form-control" id="titleInput" placeholder="Title">
         </div>
         <div class="mb-3">
           <label for="exampleFormControlTextarea1" class="form-label">Description</label>
-          <textarea class="form-control" id="exampleFormControlTextarea1 descriptionInput" rows="3"></textarea>
+          <textarea class="form-control" id="descriptionInput" rows="3"></textarea>
         </div>
         <button class="btn btn-primary" id="submitPackages">Submit</button>
       </div>

--- a/projects.html
+++ b/projects.html
@@ -43,11 +43,11 @@
         <form id="projectsForm">
         <div class="mb-3">
           <label for="exampleFormControlInput1" class="form-label">Title</label>
-          <input type="text" class="form-control" id="exampleFormControlInput1 titleInput" placeholder="Title">
+          <input type="text" class="form-control" id="titleInput" placeholder="Title">
         </div>
         <div class="mb-3">
           <label for="exampleFormControlTextarea1" class="form-label">Description</label>
-          <textarea type="text" class="form-control" id="exampleFormControlTextarea1 descriptionInput" rows="3"></textarea>
+          <textarea type="text" class="form-control" id="descriptionInput" rows="3"></textarea>
         </div>
         <button class="btn btn-primary" type="submit" id="submitProjects">Submit</button>
       </form>

--- a/repositories.html
+++ b/repositories.html
@@ -42,11 +42,11 @@
         <h1>Create new repository</h1>
         <div class="mb-3">
           <label for="exampleFormControlInput1" class="form-label">Title</label>
-          <input type="text" class="form-control" id="exampleFormControlInput1 titleInput" placeholder="Title">
+          <input type="text" class="form-control" id="titleInput" placeholder="Title">
         </div>
         <div class="mb-3">
           <label for="exampleFormControlTextarea1" class="form-label">Description</label>
-          <textarea class="form-control" id="exampleFormControlTextarea1 descriptionInput" rows="3"></textarea>
+          <textarea class="form-control" id="descriptionInput" rows="3"></textarea>
         </div>
         <button class="btn btn-primary" id="submitRepositories">Submit</button>
       </div>


### PR DESCRIPTION
Fixed some form input functionality.

Made title: newTitle, description:newDescription read instead as title: newTitle.value, description:newDescription.value, Now they will use the value on the DOM tied to those id's instead of trying to output everything that's tied to those elements.

input element id's still had default bootstrap id's on them with just our new id's appended to the end. Deleted those old default id's. This fixed it so null values are no longer being passed into the newProject.